### PR TITLE
fix: PDF 변환 시 A4 페이지를 꽉 채우지 못하는 문제 해결

### DIFF
--- a/src/app/api/pdf/data/route.ts
+++ b/src/app/api/pdf/data/route.ts
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
 
-  const entry = getData(id);
+  const entry = await getData(id);
   if (!entry) {
     return NextResponse.json({ error: "Data not found or expired" }, { status: 404 });
   }

--- a/src/app/api/pdf/route.ts
+++ b/src/app/api/pdf/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getBrowser } from "@/lib/browser";
 import { saveData } from "@/lib/pdfDataStore";
+import { A4_WIDTH_PX, A4_HEIGHT_PX } from "@/lib/pdfConstants";
 import type { ResumeData, TemplateId } from "@/types/resume";
 import { randomUUID } from "crypto";
 
@@ -30,13 +31,15 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   const id = randomUUID();
-  saveData(id, data, templateId);
+  await saveData(id, data, templateId);
 
   // 현재 서버의 origin 추출
   const origin = req.nextUrl.origin;
 
   const browser = await getBrowser();
-  const page = await browser.newPage();
+  const page = await browser.newPage({
+    viewport: { width: A4_WIDTH_PX, height: A4_HEIGHT_PX },
+  });
 
   try {
     await page.goto(`${origin}/print?id=${id}`, {

--- a/src/app/print/page.tsx
+++ b/src/app/print/page.tsx
@@ -15,7 +15,9 @@ declare global {
 
 const A4_WIDTH = 210;
 const A4_HEIGHT = 297;
-const SCALE = 2.8;
+const SCALE = 2.8; // 미리보기와 동일한 콘텐츠 스케일
+const MM_TO_PX = 96 / 25.4; // 서버 상수와 동일 (클라이언트 컴포넌트라 직접 정의)
+const TRANSFORM_RATIO = MM_TO_PX / SCALE; // ~1.35
 
 function PrintPageInner() {
   const searchParams = useSearchParams();
@@ -60,15 +62,24 @@ function PrintPageInner() {
   return (
     <div
       style={{
-        width: A4_WIDTH * SCALE,
-        height: A4_HEIGHT * SCALE,
+        width: A4_WIDTH * MM_TO_PX,
+        height: A4_HEIGHT * MM_TO_PX,
         overflow: "hidden",
-        fontFamily: "Pretendard, sans-serif",
-        wordBreak: "keep-all",
         background: "white",
       }}
     >
-      <A4Content data={data} fs={fs} contentRef={contentRef} templateId={templateId} />
+      <div
+        style={{
+          width: A4_WIDTH * SCALE,
+          height: A4_HEIGHT * SCALE,
+          transform: `scale(${TRANSFORM_RATIO})`,
+          transformOrigin: "top left",
+          fontFamily: "Pretendard, sans-serif",
+          wordBreak: "keep-all",
+        }}
+      >
+        <A4Content data={data} fs={fs} contentRef={contentRef} templateId={templateId} />
+      </div>
     </div>
   );
 }

--- a/src/lib/pdfConstants.ts
+++ b/src/lib/pdfConstants.ts
@@ -1,0 +1,10 @@
+/** A4 용지 크기 (mm) */
+export const A4_WIDTH_MM = 210;
+export const A4_HEIGHT_MM = 297;
+
+/** mm → CSS px 변환 (96dpi 기준) */
+export const MM_TO_PX = 96 / 25.4;
+
+/** A4 크기 (CSS px, 96dpi) */
+export const A4_WIDTH_PX = Math.ceil(A4_WIDTH_MM * MM_TO_PX);
+export const A4_HEIGHT_PX = Math.ceil(A4_HEIGHT_MM * MM_TO_PX);

--- a/src/lib/pdfDataStore.ts
+++ b/src/lib/pdfDataStore.ts
@@ -1,4 +1,7 @@
 import type { ResumeData, TemplateId } from "@/types/resume";
+import { writeFile, readFile, unlink } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
 
 interface PdfEntry {
   data: ResumeData;
@@ -6,19 +9,38 @@ interface PdfEntry {
   expires: number;
 }
 
-const store = new Map<string, PdfEntry>();
+const PREFIX = "resume-kr-pdf-";
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export function saveData(id: string, data: ResumeData, templateId: TemplateId = "classic"): void {
-  store.set(id, { data, templateId, expires: Date.now() + 30_000 });
+function filePath(id: string): string {
+  if (!UUID_RE.test(id)) throw new Error("Invalid id format");
+  return join(tmpdir(), `${PREFIX}${id}.json`);
 }
 
-export function getData(id: string): { data: ResumeData; templateId: TemplateId } | null {
-  const entry = store.get(id);
-  if (!entry) return null;
-  if (Date.now() > entry.expires) {
-    store.delete(id);
+export async function saveData(id: string, data: ResumeData, templateId: TemplateId = "classic"): Promise<void> {
+  const entry: PdfEntry = { data, templateId, expires: Date.now() + 30_000 };
+  await writeFile(filePath(id), JSON.stringify(entry), "utf-8");
+}
+
+export async function getData(id: string): Promise<{ data: ResumeData; templateId: TemplateId } | null> {
+  let fp: string;
+  try {
+    fp = filePath(id);
+  } catch {
     return null;
   }
-  store.delete(id); // 1회 조회 후 삭제
-  return { data: entry.data, templateId: entry.templateId };
+
+  try {
+    const raw = await readFile(fp, "utf-8");
+    const entry = JSON.parse(raw) as PdfEntry;
+    await unlink(fp);
+
+    if (Date.now() > entry.expires) return null;
+    return { data: entry.data, templateId: entry.templateId };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      await unlink(fp).catch(() => {});
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
## 요약
PDF 변환 시 콘텐츠가 페이지 왼쪽 상단에만 표시되고 A4 전체를 채우지 못하는 문제 해결. Closes #9

## 변경 사항
- `src/lib/pdfDataStore.ts`: in-memory Map → 파일 기반 임시 저장소로 변경 (Next.js 모듈 격리로 API route 간 Map이 공유되지 않는 버그 수정)
- `src/app/print/page.tsx`: 미리보기 크기(588px)를 CSS transform으로 A4 96dpi 크기(794px)에 맞게 스케일업
- `src/app/api/pdf/route.ts`: Playwright 뷰포트를 A4 96dpi 크기로 설정

## 테스트 계획
- [x] Playwright로 PDF 생성 후 A4 페이지를 꽉 채우는지 확인
- [x] 앱 내 PDF 다운로드 버튼으로 전체 플로우 정상 동작 확인