### PR TITLE
fix: 프로젝트 링크 표시 및 PDF 아이콘 렌더링 수정

### DIFF
--- a/src/__tests__/components/preview/ClassicTemplate.test.tsx
+++ b/src/__tests__/components/preview/ClassicTemplate.test.tsx
@@ -179,6 +179,55 @@ describe("ClassicTemplate", () => {
       expect(screen.getByText("React")).toBeInTheDocument();
       expect(screen.getByText("Next.js")).toBeInTheDocument();
     });
+
+    it("유효한 링크가 있으면 링크 아이콘을 표시한다", () => {
+      renderTemplate(makeData({
+        sections: [
+          { id: "sec-projects", type: "projects", title: "프로젝트", visible: true, order: 0 },
+        ],
+        projects: [{
+          id: "p1",
+          name: "이력서 빌더",
+          startDate: "2024-01",
+          description: [],
+          link: "https://github.com/user/repo",
+        }],
+      }));
+      const link = screen.getByLabelText("프로젝트 링크");
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "https://github.com/user/repo");
+    });
+
+    it("링크가 없으면 링크 아이콘을 표시하지 않는다", () => {
+      renderTemplate(makeData({
+        sections: [
+          { id: "sec-projects", type: "projects", title: "프로젝트", visible: true, order: 0 },
+        ],
+        projects: [{
+          id: "p1",
+          name: "이력서 빌더",
+          startDate: "2024-01",
+          description: [],
+        }],
+      }));
+      expect(screen.queryByLabelText("프로젝트 링크")).not.toBeInTheDocument();
+    });
+
+    it("javascript: 스킴 링크는 렌더링하지 않는다", () => {
+      renderTemplate(makeData({
+        sections: [
+          { id: "sec-projects", type: "projects", title: "프로젝트", visible: true, order: 0 },
+        ],
+        projects: [{
+          id: "p1",
+          name: "이력서 빌더",
+          startDate: "2024-01",
+          description: [],
+          link: "javascript:alert(1)",
+        }],
+      }));
+      expect(screen.queryByLabelText("프로젝트 링크")).not.toBeInTheDocument();
+    });
   });
 
   describe("자격증 섹션", () => {

--- a/src/components/preview/templates/ClassicTemplate.tsx
+++ b/src/components/preview/templates/ClassicTemplate.tsx
@@ -186,11 +186,11 @@ function ProjectsSection({
                   </span>
                 )}
               </span>
-              {item.link && (
-                <a href={item.link} target="_blank" rel="noopener noreferrer" title={item.link} aria-label="프로젝트 링크" className="inline-flex items-center text-zinc-500 hover:text-zinc-800">
+              {(() => { const safeLink = item.link ? sanitizeUrl(item.link) : undefined; return safeLink ? (
+                <a href={safeLink} target="_blank" rel="noopener noreferrer" title={safeLink} aria-label="프로젝트 링크" className="inline-flex items-center text-zinc-500 hover:text-zinc-800">
                   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
                 </a>
-              )}
+              ) : null; })()}
             </span>
             <DateRange
               startDate={item.startDate}

--- a/src/lib/pdf/templates/ClassicDocument.tsx
+++ b/src/lib/pdf/templates/ClassicDocument.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Link, StyleSheet, Svg, Path, Circle, Line, G } from "@react-pdf/renderer";
+import { View, Text, Link, StyleSheet, Svg, Path, Circle, Line } from "@react-pdf/renderer";
 import type {
   ResumeData,
   SectionType,
@@ -247,12 +247,12 @@ function ProjectsSection({ items }: { items: Project[] }) {
         return (
           <View key={item.id}>
             <View style={st.itemRow} wrap={false}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
                 <Text style={st.itemTitle}>
                   {item.name}
                   {item.role ? <Text style={st.itemSub}> ({item.role})</Text> : null}
                 </Text>
-                {item.link ? <Link src={sanitizeUrl(item.link)} style={{textDecoration: 'none'}}><LinkIcon /></Link> : null}
+                {(() => { const safeLink = item.link ? sanitizeUrl(item.link) : undefined; return safeLink ? <Link src={safeLink} style={{textDecoration: 'none'}}><LinkIcon /></Link> : null; })()}
               </View>
               <DateRange startDate={item.startDate} endDate={item.endDate} isCurrent={false} />
             </View>


### PR DESCRIPTION
## 요약
프로젝트 섹션에서 링크가 미리보기/PDF 모두에서 표시되지 않던 문제(#30)와 PDF export 시 LinkedIn/GitHub/웹사이트 아이콘이 텍스트로 대치되던 문제(#31)를 해결합니다.

## 변경 사항
- 미리보기(`ClassicTemplate.tsx`): 프로젝트 이름 옆에 링크 아이콘 추가, 클릭 시 새 탭에서 열림
- PDF(`ClassicDocument.tsx`): 프로젝트 이름 옆에 링크 아이콘 추가 (react-pdf `Svg` 컴포넌트 활용)
- PDF(`ClassicDocument.tsx`): 헤더의 LinkedIn/GitHub/웹사이트 텍스트 라벨을 react-pdf `Svg`/`Path`/`Circle`/`Line` 기반 아이콘으로 교체

## 테스트 계획
- [x] TypeScript 타입 체크 통과
- [x] Next.js 빌드 성공
- [x] Vitest 78개 테스트 전체 통과
- [ ] 프로젝트에 링크 입력 후 미리보기에서 링크 아이콘 표시 확인
- [ ] PDF export 후 프로젝트 링크 아이콘 표시 및 클릭 동작 확인
- [ ] PDF export 후 헤더 LinkedIn/GitHub/웹사이트 아이콘 표시 확인

Closes #30, Closes #31