### PR TITLE
fix: 미리보기에서 긴 텍스트가 컨테이너를 벗어나는 문제 해결

### DIFF
--- a/src/components/preview/templates/ClassicTemplate.tsx
+++ b/src/components/preview/templates/ClassicTemplate.tsx
@@ -59,7 +59,7 @@ function WorkExperienceSection({
       {filtered.map((item) => (
         <div key={item.id}>
           <div className="flex items-baseline justify-between gap-2">
-            <span style={{ fontSize: fs.fontSize }} className="font-medium">
+            <span style={{ fontSize: fs.fontSize }} className="min-w-0 flex-1 font-medium">
               {item.company}
               {item.position && (
                 <span className="ml-1 font-normal text-zinc-600">
@@ -113,7 +113,7 @@ function EducationSection({
       {filtered.map((item) => (
         <div key={item.id}>
           <div className="flex items-baseline justify-between gap-2">
-            <span style={{ fontSize: fs.fontSize }} className="font-medium">
+            <span style={{ fontSize: fs.fontSize }} className="min-w-0 flex-1 font-medium">
               {item.school}
               {(item.degree || item.field) && (
                 <span className="ml-1 font-normal text-zinc-600">
@@ -186,7 +186,7 @@ function ProjectsSection({
       {filtered.map((item) => (
         <div key={item.id}>
           <div className="flex items-baseline justify-between gap-2">
-            <span className="flex items-center gap-1">
+            <span className="flex min-w-0 flex-1 items-center gap-1">
               <span style={{ fontSize: fs.fontSize }} className="font-medium">
                 {item.name}
                 {item.role && (
@@ -258,15 +258,15 @@ function CertificatesSection({
   return (
     <div className="flex flex-col" style={{ gap: Math.max(fs.itemGap - 10, 4) }}>
       {filtered.map((item) => (
-        <div key={item.id} className="flex items-baseline justify-between">
-          <span style={{ fontSize: fs.fontSize - 2 }}>
+        <div key={item.id} className="flex items-baseline justify-between gap-2">
+          <span className="min-w-0 flex-1" style={{ fontSize: fs.fontSize - 2 }}>
             <span className="font-medium">{item.name}</span>
             {item.issuer && (
               <span className="ml-1 text-zinc-600">- {item.issuer}</span>
             )}
           </span>
           <span
-            className="text-zinc-500"
+            className="shrink-0 text-zinc-500"
             style={{ fontSize: fs.fontSize - 2 }}
           >
             {formatDate(item.date)}
@@ -307,15 +307,15 @@ function AwardsSection({ items, fs }: { items: Award[]; fs: FitStyles }) {
     <div className="flex flex-col" style={{ gap: fs.itemGap - 4 }}>
       {filtered.map((item) => (
         <div key={item.id}>
-          <div className="flex items-baseline justify-between">
-            <span style={{ fontSize: fs.fontSize - 2 }}>
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="min-w-0 flex-1" style={{ fontSize: fs.fontSize - 2 }}>
               <span className="font-medium">{item.name}</span>
               {item.issuer && (
                 <span className="ml-1 text-zinc-600">- {item.issuer}</span>
               )}
             </span>
             <span
-              className="text-zinc-500"
+              className="shrink-0 text-zinc-500"
               style={{ fontSize: fs.fontSize - 2 }}
             >
               {formatDate(item.date)}


### PR DESCRIPTION
## 요약
웹 미리보기에서 긴 텍스트(회사명+직책, 학교명+전공 등)가 줄바꿈 없이 날짜 영역이나 컨테이너 밖으로 넘치는 문제를 해결합니다. Closes #47

## 변경 내용
- `ClassicTemplate.tsx`의 5개 섹션(경력, 학력, 프로젝트, 자격증, 수상) 제목 영역에 `min-w-0 flex-1` 적용
- 자격증/수상 섹션의 날짜 요소에 `shrink-0` 추가, 행에 `gap-2` 추가
- PDF 템플릿에서 사용하는 `flex: 1, minWidth: 0` 패턴을 웹 미리보기에도 동일하게 적용

## 테스트
- [x] 각 섹션에 긴 텍스트 입력 시 날짜 영역을 침범하지 않고 줄바꿈됨 (수동 확인)
- [x] 짧은 텍스트에서 기존 레이아웃 유지됨 (수동 확인)
- [x] `npm run build` 성공