### PR TITLE
feat: 유효성 검증, localStorage 안전 처리, 오버플로우 수정

### DIFF
--- a/src/__tests__/components/preview/ClassicTemplate.test.tsx
+++ b/src/__tests__/components/preview/ClassicTemplate.test.tsx
@@ -303,6 +303,47 @@ describe("ClassicTemplate", () => {
     });
   });
 
+  describe("긴 URL / 오버플로우", () => {
+    it("긴 URL이 포함된 프로젝트를 에러 없이 렌더링한다", () => {
+      const longUrl = "https://github.com/user/very-long-repository-name-that-exceeds-normal-width/blob/main/src/components/some/deeply/nested/component.tsx";
+      renderTemplate(makeData({
+        sections: [
+          { id: "sec-projects", type: "projects", title: "프로젝트", visible: true, order: 0 },
+        ],
+        projects: [{
+          id: "p1",
+          name: "테스트 프로젝트",
+          startDate: "2024-01",
+          description: [],
+          link: longUrl,
+        }],
+      }));
+      const link = screen.getByLabelText("프로젝트 링크");
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", longUrl);
+    });
+
+    it("긴 URL이 포함된 커스텀 섹션을 에러 없이 렌더링한다", () => {
+      const longUrl = "https://example.com/verylongpathwithoutspacessoitwilloverflowthecontainerunlessbreakallisapplied";
+      renderTemplate(makeData({
+        sections: [
+          { id: "sec-custom-1", type: "custom", title: "포트폴리오", visible: true, order: 0, fieldDefinitions: [
+            { id: "fd-link", label: "링크", type: "link" },
+          ]},
+        ],
+        customSections: {
+          "sec-custom-1": [{
+            id: "item-1",
+            fields: [{ fieldId: "fd-link", value: longUrl }],
+          }],
+        },
+      }));
+      const link = screen.getByRole("link", { name: longUrl });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveClass("break-all");
+    });
+  });
+
   describe("섹션 순서", () => {
     it("order에 따라 섹션이 정렬된다", () => {
       renderTemplate(makeData({

--- a/src/__tests__/lib/safeStorage.test.ts
+++ b/src/__tests__/lib/safeStorage.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { safeGetItem, safeSetItem, safeRemoveItem } from "@/lib/safeStorage";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("safeGetItem", () => {
+  it("localStorage에 값이 있으면 반환한다", () => {
+    localStorage.setItem("test-key", "test-value");
+    expect(safeGetItem("test-key")).toBe("test-value");
+  });
+
+  it("예외 발생 시 null을 반환하고 예외를 전파하지 않는다", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => safeGetItem("test-key")).not.toThrow();
+    expect(safeGetItem("test-key")).toBeNull();
+  });
+});
+
+describe("safeSetItem", () => {
+  it("localStorage에 값을 저장한다", () => {
+    safeSetItem("test-key", "test-value");
+    expect(localStorage.getItem("test-key")).toBe("test-value");
+  });
+
+  it("예외 발생 시 예외를 전파하지 않는다", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => safeSetItem("test-key", "test-value")).not.toThrow();
+  });
+});
+
+describe("safeRemoveItem", () => {
+  it("localStorage에서 값을 제거한다", () => {
+    localStorage.setItem("test-key", "test-value");
+    safeRemoveItem("test-key");
+    expect(localStorage.getItem("test-key")).toBeNull();
+  });
+
+  it("예외 발생 시 예외를 전파하지 않는다", () => {
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => safeRemoveItem("test-key")).not.toThrow();
+  });
+});

--- a/src/__tests__/lib/validation.test.ts
+++ b/src/__tests__/lib/validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { validateEmail, validatePhone } from "@/lib/validation";
+
+describe("validateEmail", () => {
+  it("빈 문자열 → null", () => {
+    expect(validateEmail("")).toBeNull();
+  });
+
+  it("user@example.com → null", () => {
+    expect(validateEmail("user@example.com")).toBeNull();
+  });
+
+  it("user+tag@sub.example.com → null", () => {
+    expect(validateEmail("user+tag@sub.example.com")).toBeNull();
+  });
+
+  it("invalid → 에러 메시지", () => {
+    expect(validateEmail("invalid")).toBe("올바른 이메일 형식이 아닙니다");
+  });
+
+  it("@example.com → 에러 메시지", () => {
+    expect(validateEmail("@example.com")).toBe("올바른 이메일 형식이 아닙니다");
+  });
+
+  it("user@ → 에러 메시지", () => {
+    expect(validateEmail("user@")).toBe("올바른 이메일 형식이 아닙니다");
+  });
+
+  it("공백 포함 → 에러 메시지", () => {
+    expect(validateEmail("user @example.com")).toBe("올바른 이메일 형식이 아닙니다");
+  });
+});
+
+describe("validatePhone", () => {
+  it("빈 문자열 → null", () => {
+    expect(validatePhone("")).toBeNull();
+  });
+
+  it("010-1234-5678 → null", () => {
+    expect(validatePhone("010-1234-5678")).toBeNull();
+  });
+
+  it("01012345678 → null", () => {
+    expect(validatePhone("01012345678")).toBeNull();
+  });
+
+  it("02-123-4567 → null", () => {
+    expect(validatePhone("02-123-4567")).toBeNull();
+  });
+
+  it("021234567 → null", () => {
+    expect(validatePhone("021234567")).toBeNull();
+  });
+
+  it("abc → 에러 메시지", () => {
+    expect(validatePhone("abc")).toBe("올바른 전화번호 형식이 아닙니다");
+  });
+
+  it("123 → 에러 메시지", () => {
+    expect(validatePhone("123")).toBe("올바른 전화번호 형식이 아닙니다");
+  });
+
+  it("010-123-456 (짧음) → 에러 메시지", () => {
+    expect(validatePhone("010-123-456")).toBe("올바른 전화번호 형식이 아닙니다");
+  });
+});

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { validateEmail, validatePhone } from "@/lib/validation";
 import {
   DndContext,
   PointerSensor,
@@ -77,6 +78,7 @@ function SectionIcon({ type }: { type: string }) {
 function PersonalInfoEditor() {
   const { data, updatePersonalInfo } = useResumeStore();
   const { personalInfo } = data;
+  const [errors, setErrors] = useState<{ email?: string; phone?: string }>({});
   return (
     <div className="flex flex-col gap-2.5">
       <input
@@ -87,20 +89,44 @@ function PersonalInfoEditor() {
         className={INPUT}
       />
       <div className="grid grid-cols-2 gap-2.5 min-w-0">
-        <input
-          type="email"
-          placeholder="이메일"
-          value={personalInfo.email}
-          onChange={(e) => updatePersonalInfo({ email: e.target.value })}
-          className={INPUT}
-        />
-        <input
-          type="tel"
-          placeholder="전화번호"
-          value={personalInfo.phone}
-          onChange={(e) => updatePersonalInfo({ phone: e.target.value })}
-          className={INPUT}
-        />
+        <div>
+          <input
+            type="email"
+            placeholder="이메일"
+            value={personalInfo.email}
+            onChange={(e) => {
+              updatePersonalInfo({ email: e.target.value });
+              if (errors.email) setErrors((prev) => ({ ...prev, email: undefined }));
+            }}
+            onBlur={(e) => {
+              const msg = validateEmail(e.target.value);
+              setErrors((prev) => ({ ...prev, email: msg ?? undefined }));
+            }}
+            className={`${INPUT}${errors.email ? " ring-1 ring-red-400" : ""}`}
+          />
+          {errors.email && (
+            <p className="text-red-500 text-xs mt-1">{errors.email}</p>
+          )}
+        </div>
+        <div>
+          <input
+            type="tel"
+            placeholder="전화번호"
+            value={personalInfo.phone}
+            onChange={(e) => {
+              updatePersonalInfo({ phone: e.target.value });
+              if (errors.phone) setErrors((prev) => ({ ...prev, phone: undefined }));
+            }}
+            onBlur={(e) => {
+              const msg = validatePhone(e.target.value);
+              setErrors((prev) => ({ ...prev, phone: msg ?? undefined }));
+            }}
+            className={`${INPUT}${errors.phone ? " ring-1 ring-red-400" : ""}`}
+          />
+          {errors.phone && (
+            <p className="text-red-500 text-xs mt-1">{errors.phone}</p>
+          )}
+        </div>
       </div>
       <input
         type="text"

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -72,6 +72,7 @@ export default function Preview() {
               minHeight: BASE_HEIGHT,
               fontFamily: "Pretendard, sans-serif",
               wordBreak: "keep-all",
+              overflowWrap: "break-word",
               transform: `scale(${zoom})`,
               transformOrigin: "top left",
               backgroundImage: `repeating-linear-gradient(

--- a/src/components/preview/templates/ClassicTemplate.tsx
+++ b/src/components/preview/templates/ClassicTemplate.tsx
@@ -378,7 +378,7 @@ function CustomSection({
               case "link": {
                 const safeLink = typeof val === "string" ? sanitizeUrl(val) : undefined;
                 return safeLink ? (
-                  <a key={def.id} href={safeLink} target="_blank" rel="noopener noreferrer" className="text-zinc-600 hover:text-zinc-800" style={{ fontSize: fs.fontSize - 2 }}>
+                  <a key={def.id} href={safeLink} target="_blank" rel="noopener noreferrer" className="text-zinc-600 hover:text-zinc-800 break-all" style={{ fontSize: fs.fontSize - 2 }}>
                     {val}
                   </a>
                 ) : null;

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { safeGetItem, safeSetItem } from "@/lib/safeStorage";
 
 const STORAGE_KEY = "sidebar-width";
 const DEFAULT_WIDTH = 420;
@@ -30,7 +31,7 @@ export function useResizable() {
 
   // localStorage에서 저장된 너비 복원 (hydration 이후)
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = safeGetItem(STORAGE_KEY);
     if (stored) {
       const parsed = Number(stored);
       if (!Number.isNaN(parsed) && parsed >= MIN_WIDTH && parsed <= STATIC_MAX) {
@@ -49,7 +50,7 @@ export function useResizable() {
 
   const handleDoubleClick = useCallback(() => {
     setWidth(DEFAULT_WIDTH);
-    localStorage.setItem(STORAGE_KEY, String(DEFAULT_WIDTH));
+    safeSetItem(STORAGE_KEY, String(DEFAULT_WIDTH));
   }, []);
 
   useEffect(() => {
@@ -68,7 +69,7 @@ export function useResizable() {
       isDragging.current = false;
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
-      localStorage.setItem(STORAGE_KEY, String(widthRef.current));
+      safeSetItem(STORAGE_KEY, String(widthRef.current));
     };
 
     window.addEventListener("mousemove", handleMouseMove);
@@ -83,7 +84,7 @@ export function useResizable() {
     const clamped = Math.min(maxWidthRef.current, Math.max(MIN_WIDTH, desired));
     if (clamped > widthRef.current) {
       setWidth(clamped);
-      localStorage.setItem(STORAGE_KEY, String(clamped));
+      safeSetItem(STORAGE_KEY, String(clamped));
     }
   }, []);
 

--- a/src/lib/safeStorage.ts
+++ b/src/lib/safeStorage.ts
@@ -1,0 +1,23 @@
+export function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // 프라이빗 브라우징 등에서 실패 가능 — 무시
+  }
+}
+
+export function safeRemoveItem(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // 무시
+  }
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,13 @@
+// null = 유효, string = 에러 메시지
+
+export function validateEmail(v: string): string | null {
+  if (v === "") return null;
+  const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return re.test(v) ? null : "올바른 이메일 형식이 아닙니다";
+}
+
+export function validatePhone(v: string): string | null {
+  if (v === "") return null;
+  const re = /^(0\d{1,2})-?\d{3,4}-?\d{4}$/;
+  return re.test(v) ? null : "올바른 전화번호 형식이 아닙니다";
+}

--- a/src/store/resume.ts
+++ b/src/store/resume.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { safeGetItem, safeSetItem, safeRemoveItem } from "@/lib/safeStorage";
 import type {
   ResumeData,
   Section,
@@ -352,6 +353,11 @@ export const useResumeStore = create<ResumeStore>()(
     },
     {
       name: "resume-kr-storage",
+      storage: createJSONStorage(() => ({
+        getItem: safeGetItem,
+        setItem: safeSetItem,
+        removeItem: safeRemoveItem,
+      })),
       version: 3,
       partialize: (state) => ({ data: state.data, templateId: state.templateId }),
       migrate: (persisted: unknown) => {


### PR DESCRIPTION
## 요약
- 방어적 품질 개선 4건을 일괄 처리

## 변경 내용
- **이메일/전화번호 유효성 검증**: `validation.ts` 신규, blur 시 시각적 경고 (스토어 저장은 차단하지 않음)
- **localStorage try-catch 보강**: `safeStorage.ts` 신규, `useResizable`/Zustand persist에 적용하여 프라이빗 브라우징 크래시 방지
- **긴 URL 오버플로우**: Preview에 `overflowWrap: break-word` 추가, 한글 줄바꿈 유지하면서 URL만 강제 줄바꿈
- **커스텀 섹션 오버플로우**: link 타입 필드에 `break-all` 적용

## 테스트
- [ ] 잘못된 이메일/전화번호 입력 후 blur → 빨간 테두리 + 에러 메시지 표시
- [ ] 올바른 값 입력 또는 빈 값 → 에러 없음
- [ ] 프라이빗 브라우징에서 앱 정상 동작
- [ ] 100자 이상 URL이 미리보기에서 줄바꿈됨
- [ ] 커스텀 섹션 link 필드의 긴 URL 줄바꿈 정상
- [x] Vitest 125개 전체 통과